### PR TITLE
Introduce BaseRecyclerViewViewHolder

### DIFF
--- a/animators/build.gradle
+++ b/animators/build.gradle
@@ -28,12 +28,14 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.recyclerview:recyclerview:$recycler_version"
 
-    testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+
+    testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
     testImplementation "org.mockito:mockito-core:3.0.0"
+
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {
@@ -44,7 +46,7 @@ repositories {
 publish {
     def groupProjectID = 'com.revolut.recyclerkit'
     def artifactProjectID = 'animators'
-    def publishVersionID = '1.0'
+    def publishVersionID = '1.0.5'
 
     userOrg = 'revolut-mobile'
     repoName = 'RecyclerKit'

--- a/app/src/main/java/com/revolut/recyclerkit/sample/delegates/ImageFixedSizeTextDelegate.kt
+++ b/app/src/main/java/com/revolut/recyclerkit/sample/delegates/ImageFixedSizeTextDelegate.kt
@@ -19,6 +19,7 @@ import com.revolut.decorations.overlay.OverlayDecoratedItem
 import com.revolut.decorations.overlay.delegates.OverlayDecorationDelegate
 import com.revolut.recyclerkit.animations.holder.AnimateChangeViewHolder
 import com.revolut.recyclerkit.delegates.BaseRecyclerViewDelegate
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
 import com.revolut.recyclerkit.delegates.ListItem
 import com.revolut.recyclerkit.sample.R
 import com.revolut.recyclerkit.sample.delegates.ImageFixedSizeTextDelegate.Model
@@ -41,6 +42,7 @@ class ImageFixedSizeTextDelegate(
         ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.image_fixed_size_text_delegate, parent, false))
 
     override fun onBindViewHolder(holder: ViewHolder, data: Model, pos: Int, payloads: List<Any>?) {
+        super.onBindViewHolder(holder, data, pos, payloads)
         payloads?.filterIsInstance<Payload>()
             ?.forEach { payload -> holder.applyPayload(payload) }
 
@@ -105,7 +107,7 @@ class ImageFixedSizeTextDelegate(
 
     }
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView), AnimateChangeViewHolder {
+    class ViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView), AnimateChangeViewHolder {
 
         override fun canAnimateChange(payloads: List<Any>): Boolean {
             //Animates only when Model.text changes

--- a/app/src/main/java/com/revolut/recyclerkit/sample/delegates/ImageWrapSizeTextDelegate.kt
+++ b/app/src/main/java/com/revolut/recyclerkit/sample/delegates/ImageWrapSizeTextDelegate.kt
@@ -5,13 +5,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.signature.ObjectKey
 import com.revolut.decorations.dividers.DividerDecoratedItem
 import com.revolut.decorations.dividers.delegates.DividerDecorationDelegate
 import com.revolut.recyclerkit.delegates.BaseRecyclerViewDelegate
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
 import com.revolut.recyclerkit.delegates.ListItem
 import com.revolut.recyclerkit.sample.R
 import kotlinx.android.synthetic.main.image_wrap_size_text_delegate.view.*
@@ -27,6 +27,7 @@ class ImageWrapSizeTextDelegate(
         ViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.image_wrap_size_text_delegate, parent, false))
 
     override fun onBindViewHolder(holder: ViewHolder, data: Model, pos: Int, payloads: List<Any>?) {
+        super.onBindViewHolder(holder, data, pos, payloads)
         holder.takeIf { payloads.isNullOrEmpty() }?.applyData(data)
     }
 
@@ -54,7 +55,7 @@ class ImageWrapSizeTextDelegate(
         override var rightDecoration: DividerDecorationDelegate? = null
     ) : ListItem, DividerDecoratedItem
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    class ViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView) {
         val textView: TextView = itemView.textView
         val imageView: ImageView = itemView.imageView
     }

--- a/decorations/build.gradle
+++ b/decorations/build.gradle
@@ -35,12 +35,17 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:4.3'
+    testImplementation 'com.nhaarman:mockito-kotlin:1.5.0'
+    testImplementation "org.mockito:mockito-core:3.0.0"
 }
 
 publish {
     def groupProjectID = 'com.revolut.recyclerkit'
     def artifactProjectID = 'decorations'
-    def publishVersionID = '1.0.3'
+    def publishVersionID = '1.0.5'
 
     userOrg = 'revolut-mobile'
     repoName = 'RecyclerKit'

--- a/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
+++ b/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
@@ -21,6 +21,5 @@ import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
  */
 
 internal fun RecyclerView.forEachBaseViewHolder(block: (viewHolder: BaseRecyclerViewHolder) -> Unit) = (0 until childCount).map { getChildAt(it) }.forEach { view ->
-    getChildViewHolder(view)?.let { it as? BaseRecyclerViewHolder }?.run(block)
+(getChildViewHolder(view) as? BaseRecyclerViewHolder)?.run(block)
 }
-

--- a/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
+++ b/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
@@ -20,6 +20,6 @@ import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
  *
  */
 
-internal fun RecyclerView.forEachBaseViewHolder(block: (viewHolder: BaseRecyclerViewHolder) -> Unit) = (0 until childCount).map { getChildAt(it) }.forEach { view ->
+internal fun RecyclerView.forEachBaseViewHolder(block: (viewHolder: BaseRecyclerViewHolder) -> Unit) = (0 until childCount).asSequence().map { getChildAt(it) }.forEach { view ->
     (getChildViewHolder(view) as? BaseRecyclerViewHolder)?.run(block)
 }

--- a/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
+++ b/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
@@ -1,7 +1,7 @@
 package com.revolut.decorations
 
-import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
 
 /*
  * Copyright (C) 2019 Revolut
@@ -20,9 +20,7 @@ import androidx.recyclerview.widget.RecyclerView
  *
  */
 
-internal fun RecyclerView.forEachViewAdapterPosition(block: (view: View, pos: Int) -> Unit) = (0 until childCount).map { getChildAt(it) }.forEach { view ->
-    getChildAdapterPosition(view).takeUnless { pos -> pos == RecyclerView.NO_POSITION }?.let { pos ->
-        block(view, pos)
-    }
+internal fun RecyclerView.forEachBaseViewHolder(block: (viewHolder: BaseRecyclerViewHolder) -> Unit) = (0 until childCount).map { getChildAt(it) }.forEach { view ->
+    getChildViewHolder(view)?.let { it as? BaseRecyclerViewHolder }?.run(block)
 }
 

--- a/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
+++ b/decorations/src/main/java/com/revolut/decorations/DecorationsExt.kt
@@ -21,5 +21,5 @@ import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
  */
 
 internal fun RecyclerView.forEachBaseViewHolder(block: (viewHolder: BaseRecyclerViewHolder) -> Unit) = (0 until childCount).map { getChildAt(it) }.forEach { view ->
-(getChildViewHolder(view) as? BaseRecyclerViewHolder)?.run(block)
+    (getChildViewHolder(view) as? BaseRecyclerViewHolder)?.run(block)
 }

--- a/decorations/src/main/java/com/revolut/decorations/dividers/DelegatesDividerItemDecoration.kt
+++ b/decorations/src/main/java/com/revolut/decorations/dividers/DelegatesDividerItemDecoration.kt
@@ -4,8 +4,8 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import com.revolut.decorations.forEachViewAdapterPosition
-import com.revolut.recyclerkit.delegates.AbsRecyclerDelegatesAdapter
+import com.revolut.decorations.forEachBaseViewHolder
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
 
 /*
  * Copyright (C) 2019 Revolut
@@ -30,18 +30,17 @@ class DelegatesDividerItemDecoration : RecyclerView.ItemDecoration() {
 
     override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         super.onDraw(canvas, parent, state)
-        val adapter = parent.adapter as? AbsRecyclerDelegatesAdapter ?: return
 
         canvas.save()
         rect.set(parent.paddingLeft, parent.paddingTop, parent.width - parent.paddingRight, parent.height - parent.paddingBottom)
         canvas.clipRect(rect)
 
-        parent.forEachViewAdapterPosition { view, pos ->
-            (adapter.getItem(pos) as? DividerDecoratedItem)?.run {
-                topDecoration?.onDrawTop(canvas, view, parent, state)
-                bottomDecoration?.onDrawBottom(canvas, view, parent, state)
-                leftDecoration?.onDrawLeft(canvas, view, parent, state)
-                rightDecoration?.onDrawRight(canvas, view, parent, state)
+        parent.forEachBaseViewHolder { vh ->
+            (vh.lastBoundItem as? DividerDecoratedItem)?.run {
+                topDecoration?.onDrawTop(canvas, vh.itemView, parent, state)
+                bottomDecoration?.onDrawBottom(canvas, vh.itemView, parent, state)
+                leftDecoration?.onDrawLeft(canvas, vh.itemView, parent, state)
+                rightDecoration?.onDrawRight(canvas, vh.itemView, parent, state)
             }
         }
         canvas.restore()
@@ -49,31 +48,26 @@ class DelegatesDividerItemDecoration : RecyclerView.ItemDecoration() {
 
     override fun onDrawOver(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         super.onDrawOver(canvas, parent, state)
-        val adapter = parent.adapter as? AbsRecyclerDelegatesAdapter ?: return
 
         canvas.save()
         rect.set(parent.paddingLeft, parent.paddingTop, parent.width - parent.paddingRight, parent.height - parent.paddingBottom)
         canvas.clipRect(rect)
 
-        parent.forEachViewAdapterPosition { view, pos ->
-            (adapter.getItem(pos) as? DividerDecoratedItem)?.run {
-                topDecoration?.onDrawOverTop(canvas, view, parent, state)
-                bottomDecoration?.onDrawOverBottom(canvas, view, parent, state)
-                leftDecoration?.onDrawOverLeft(canvas, view, parent, state)
-                rightDecoration?.onDrawOverRight(canvas, view, parent, state)
+        parent.forEachBaseViewHolder { vh ->
+            (vh.lastBoundItem as? DividerDecoratedItem)?.run {
+                topDecoration?.onDrawOverTop(canvas, vh.itemView, parent, state)
+                bottomDecoration?.onDrawOverBottom(canvas, vh.itemView, parent, state)
+                leftDecoration?.onDrawOverLeft(canvas, vh.itemView, parent, state)
+                rightDecoration?.onDrawOverRight(canvas, vh.itemView, parent, state)
             }
         }
         canvas.restore()
     }
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
-        val adapter = parent.adapter as? AbsRecyclerDelegatesAdapter ?: return
-        val pos = parent.getChildAdapterPosition(view)
-        if (pos == RecyclerView.NO_POSITION) {
-            return
-        }
+        val item = (parent.findContainingViewHolder(view) as? BaseRecyclerViewHolder)?.lastBoundItem ?: return
 
-        (adapter.getItem(pos) as? DividerDecoratedItem)?.run {
+        (item as? DividerDecoratedItem)?.run {
             topDecoration?.getItemOffsetsTop(outRect, view, parent, state)
             bottomDecoration?.getItemOffsetsBottom(outRect, view, parent, state)
             leftDecoration?.getItemOffsetsLeft(outRect, view, parent, state)

--- a/decorations/src/main/java/com/revolut/decorations/frames/DelegatesFrameItemDecoration.kt
+++ b/decorations/src/main/java/com/revolut/decorations/frames/DelegatesFrameItemDecoration.kt
@@ -4,8 +4,8 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import com.revolut.decorations.forEachViewAdapterPosition
-import com.revolut.recyclerkit.delegates.AbsRecyclerDelegatesAdapter
+import com.revolut.decorations.forEachBaseViewHolder
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
 
 /*
  * Copyright (C) 2019 Revolut
@@ -30,14 +30,13 @@ class DelegatesFrameItemDecoration : RecyclerView.ItemDecoration() {
     override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         super.onDraw(canvas, parent, state)
 
-        val adapter = parent.adapter as? AbsRecyclerDelegatesAdapter ?: return
         canvas.save()
         rect.set(parent.paddingLeft, parent.paddingTop, parent.width - parent.paddingRight, parent.height - parent.paddingBottom)
         canvas.clipRect(rect)
 
-        parent.forEachViewAdapterPosition { view, pos ->
-            (adapter.getItem(pos) as? FrameDecoratedItem)?.run {
-                frameDecoration?.onDraw(canvas, view, parent, state)
+        parent.forEachBaseViewHolder { vh ->
+            (vh.lastBoundItem as? FrameDecoratedItem)?.run {
+                frameDecoration?.onDraw(canvas, vh.itemView, parent, state)
             }
         }
         canvas.restore()
@@ -45,35 +44,24 @@ class DelegatesFrameItemDecoration : RecyclerView.ItemDecoration() {
 
     override fun onDrawOver(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         super.onDrawOver(canvas, parent, state)
-        val adapter = parent.adapter as? AbsRecyclerDelegatesAdapter ?: return
 
         canvas.save()
         rect.set(parent.paddingLeft, parent.paddingTop, parent.width - parent.paddingRight, parent.height - parent.paddingBottom)
         canvas.clipRect(rect)
 
-        parent.forEachViewAdapterPosition { view, pos ->
-            (adapter.getItem(pos) as? FrameDecoratedItem)?.run {
-                frameDecoration?.onDrawOver(canvas, view, parent, state)
+        parent.forEachBaseViewHolder { vh ->
+            (vh.lastBoundItem as? FrameDecoratedItem)?.run {
+                frameDecoration?.onDrawOver(canvas, vh.itemView, parent, state)
             }
         }
         canvas.restore()
     }
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
-        val adapter = parent.adapter
 
-        if (adapter != null && adapter is AbsRecyclerDelegatesAdapter) {
-
-            val pos = parent.getChildAdapterPosition(view)
-            if (pos == RecyclerView.NO_POSITION) {
-                return
-            }
-
-            val item = adapter.getItem(pos)
-
-            if (item is FrameDecoratedItem) {
-                item.frameDecoration?.getItemOffsets(outRect, view, parent, state)
-            }
+        val item = (parent.findContainingViewHolder(view) as? BaseRecyclerViewHolder)?.lastBoundItem ?: return
+        if (item is FrameDecoratedItem) {
+            item.frameDecoration?.getItemOffsets(outRect, view, parent, state)
         }
     }
 

--- a/decorations/src/test/java/com/revolut/decorations/dividers/DelegatesDividerItemDecorationTest.kt
+++ b/decorations/src/test/java/com/revolut/decorations/dividers/DelegatesDividerItemDecorationTest.kt
@@ -1,0 +1,159 @@
+package com.revolut.decorations.dividers
+
+import android.app.Activity
+import android.content.Context
+import android.graphics.Canvas
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import com.revolut.decorations.dividers.delegates.DividerDecorationDelegate
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
+import com.revolut.recyclerkit.delegates.DiffAdapter
+import com.revolut.recyclerkit.delegates.ListItem
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DelegatesDividerItemDecorationTest {
+
+    private val delegatesDividerItemDecoration = DelegatesDividerItemDecoration()
+
+    lateinit var activity: Activity
+
+    lateinit var recyclerView: RecyclerView
+    lateinit var canvas: Canvas
+    lateinit var recyclerViewState: RecyclerView.State
+
+    @Before
+    fun setUp() {
+        val activityController = Robolectric.buildActivity(Activity::class.java)
+        activity = activityController.get()
+        recyclerView = mock()
+        canvas = mock()
+        recyclerViewState = RecyclerView.State()
+    }
+
+    @Test
+    fun `WHEN topDecoration is provided THEN onDrawTop is called for relevant View`() {
+
+        val testItem = TestListItem(
+            topDecoration = mock(),
+            mockView = MockView(activity, position = 0)
+        )
+
+        recyclerView.setUpMockedRecyclerView(listOf(testItem))
+
+        delegatesDividerItemDecoration.onDraw(
+            canvas, recyclerView, recyclerViewState
+        )
+
+        verify(testItem.topDecoration!!).onDrawTop(canvas, testItem.mockView, recyclerView, recyclerViewState)
+        verify(testItem.topDecoration!!, times(0)).onDrawBottom(any(), any(), any(), any())
+        verify(testItem.topDecoration!!, times(0)).onDrawLeft(any(), any(), any(), any())
+        verify(testItem.topDecoration!!, times(0)).onDrawRight(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `WHEN bottomDecoration is provided THEN onDrawBottom is called for relevant View`() {
+        val testItem = TestListItem(
+            bottomDecoration = mock(),
+            mockView = MockView(activity, position = 0)
+        )
+
+        recyclerView.setUpMockedRecyclerView(listOf(testItem))
+
+        delegatesDividerItemDecoration.onDraw(
+            canvas, recyclerView, recyclerViewState
+        )
+
+        verify(testItem.bottomDecoration!!).onDrawBottom(canvas, testItem.mockView, recyclerView, recyclerViewState)
+        verify(testItem.bottomDecoration!!, times(0)).onDrawTop(any(), any(), any(), any())
+        verify(testItem.bottomDecoration!!, times(0)).onDrawLeft(any(), any(), any(), any())
+        verify(testItem.bottomDecoration!!, times(0)).onDrawRight(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `WHEN leftDecoration is provided THEN onDrawLeft is called for relevant View`() {
+        val testItem = TestListItem(
+            leftDecoration = mock(),
+            mockView = MockView(activity, position = 0)
+        )
+
+        recyclerView.setUpMockedRecyclerView(listOf(testItem))
+
+        delegatesDividerItemDecoration.onDraw(
+            canvas, recyclerView, recyclerViewState
+        )
+
+        verify(testItem.leftDecoration!!).onDrawLeft(canvas, testItem.mockView, recyclerView, recyclerViewState)
+        verify(testItem.leftDecoration!!, times(0)).onDrawTop(any(), any(), any(), any())
+        verify(testItem.leftDecoration!!, times(0)).onDrawBottom(any(), any(), any(), any())
+        verify(testItem.leftDecoration!!, times(0)).onDrawRight(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `WHEN rightDecoration is provided THEN onDrawRight is called for relevant View`() {
+        val testItem = TestListItem(
+            rightDecoration = mock(),
+            mockView = MockView(activity, position = 0)
+        )
+
+        recyclerView.setUpMockedRecyclerView(listOf(testItem))
+
+        delegatesDividerItemDecoration.onDraw(
+            canvas, recyclerView, recyclerViewState
+        )
+
+        verify(testItem.rightDecoration!!).onDrawRight(canvas, testItem.mockView, recyclerView, recyclerViewState)
+        verify(testItem.rightDecoration!!, times(0)).onDrawTop(any(), any(), any(), any())
+        verify(testItem.rightDecoration!!, times(0)).onDrawBottom(any(), any(), any(), any())
+        verify(testItem.rightDecoration!!, times(0)).onDrawLeft(any(), any(), any(), any())
+    }
+
+}
+
+private fun RecyclerView.setUpMockedRecyclerView(
+    listItems: List<TestListItem>
+) {
+    val adapter = DiffAdapter().apply { setItems(listItems) }
+
+    whenever(childCount).thenReturn(adapter.itemCount)
+
+    listItems.forEach { testListItem ->
+        whenever(getChildAt(testListItem.mockView.position)).thenReturn(testListItem.mockView)
+        val mockVieHolder = mockViewHolder(testListItem.mockView, testListItem)
+        whenever(getChildViewHolder(testListItem.mockView)).thenReturn(mockVieHolder)
+    }
+
+}
+
+private fun mockViewHolder(
+    view: MockView,
+    listItem: TestListItem
+): BaseRecyclerViewHolder = spy(TestViewHolder(itemView = view)).apply {
+    whenever(this.lastBoundItem).thenReturn(listItem)
+}
+
+private class TestViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView)
+
+private data class TestListItem(
+    override val listId: String = "",
+    val mockView: MockView,
+    override var topDecoration: DividerDecorationDelegate? = null,
+    override var bottomDecoration: DividerDecorationDelegate? = null,
+    override var leftDecoration: DividerDecorationDelegate? = null,
+    override var rightDecoration: DividerDecorationDelegate? = null
+) : ListItem, DividerDecoratedItem
+
+private class MockView(
+    context: Context,
+    val position: Int
+) : View(context)

--- a/decorations/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/decorations/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/delegates/build.gradle
+++ b/delegates/build.gradle
@@ -37,7 +37,7 @@ repositories {
 publish {
     def groupProjectID = 'com.revolut.recyclerkit'
     def artifactProjectID = 'delegates'
-    def publishVersionID = '1.0.4'
+    def publishVersionID = '1.0.5'
 
     userOrg = 'revolut-mobile'
     repoName = 'RecyclerKit'

--- a/delegates/src/main/java/com/revolut/recyclerkit/delegates/BaseRecyclerViewDelegate.kt
+++ b/delegates/src/main/java/com/revolut/recyclerkit/delegates/BaseRecyclerViewDelegate.kt
@@ -1,5 +1,6 @@
 package com.revolut.recyclerkit.delegates
 
+import androidx.annotation.CallSuper
 import androidx.recyclerview.widget.RecyclerView
 
 /*
@@ -21,12 +22,17 @@ import androidx.recyclerview.widget.RecyclerView
  *
  */
 
-abstract class BaseRecyclerViewDelegate<T : ListItem, VH : RecyclerView.ViewHolder> constructor(
+abstract class BaseRecyclerViewDelegate<T : ListItem, VH : BaseRecyclerViewHolder> constructor(
     override val viewType: Int,
     private val rule: (pos: Int, data: Any) -> Boolean
 ) : RecyclerViewDelegate<T, VH> {
 
     override fun suitFor(position: Int, data: Any): Boolean = rule(position, data)
+
+    @CallSuper
+    override fun onBindViewHolder(holder: VH, data: T, pos: Int, payloads: List<Any>?) {
+        holder.lastBoundItem = data
+    }
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
         //do nothing by default

--- a/delegates/src/main/java/com/revolut/recyclerkit/delegates/BaseRecyclerViewHolder.kt
+++ b/delegates/src/main/java/com/revolut/recyclerkit/delegates/BaseRecyclerViewHolder.kt
@@ -1,11 +1,11 @@
-package com.revolut.decorations.overlay
+package com.revolut.recyclerkit.delegates
 
-import android.graphics.Canvas
+import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import com.revolut.decorations.forEachBaseViewHolder
 
 /*
  * Copyright (C) 2019 Revolut
+ * Copyright (C) 2014 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,11 @@ import com.revolut.decorations.forEachBaseViewHolder
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ *
  */
-class DelegatesOverlayItemDecoration : RecyclerView.ItemDecoration() {
+abstract class BaseRecyclerViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
-    override fun onDrawOver(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
-        parent.forEachBaseViewHolder { vh ->
-            val item = vh.lastBoundItem
-
-            if (item is OverlayDecoratedItem) {
-                item.overlayColorDecoration?.onDrawOver(canvas, parent, vh.itemView)
-            }
-        }
-    }
+    var lastBoundItem: ListItem? = null
+        internal set
 
 }
-

--- a/rxdiffadapter/build.gradle
+++ b/rxdiffadapter/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 publish {
     def groupProjectID = 'com.revolut.recyclerkit'
     def artifactProjectID = 'rxdiffadapter'
-    def publishVersionID = '1.0.3'
+    def publishVersionID = '1.0.5'
 
     userOrg = 'revolut-mobile'
     repoName = 'RecyclerKit'


### PR DESCRIPTION
...and lastBoundItem logic to support decorations during animations.

The previous implementation of Decorators couldn't obtain DecoratedItems
from an adapter in certain states (e.g. when removal animation was played).

Also introduces the first test class for DividerItemDecorator and modules version alignment to 1.0.5. 