### PR TITLE
[Improvements] Constructor with delegates becomes to be deprecated

### DIFF
--- a/app/src/main/java/com/revolut/recyclerkit/sample/MainActivity.kt
+++ b/app/src/main/java/com/revolut/recyclerkit/sample/MainActivity.kt
@@ -7,7 +7,6 @@ import com.revolut.decorations.dividers.DelegatesDividerItemDecoration
 import com.revolut.decorations.frames.DelegatesFrameItemDecoration
 import com.revolut.decorations.overlay.DelegatesOverlayItemDecoration
 import com.revolut.recyclerkit.animations.FadeInAnimator
-import com.revolut.recyclerkit.delegates.DelegatesManager
 import com.revolut.recyclerkit.delegates.ListItem
 import com.revolut.recyclerkit.sample.PaddingDecorations.PADDING_16DP
 import com.revolut.recyclerkit.sample.delegates.ImageFixedSizeTextDelegate
@@ -69,12 +68,13 @@ class MainActivity : AppCompatActivity() {
     ).toMutableList()
 
     private val adapter by lazy {
-        RxDiffAdapter(async = true, delegatesManager = DelegatesManager()
-            .addDelegate(
-                ImageFixedSizeTextDelegate { model -> onClick(model) }
-            ).addDelegate(
+        RxDiffAdapter(
+            async = true,
+            delegates = listOf(
+                ImageFixedSizeTextDelegate { model -> onClick(model) },
                 ImageWrapSizeTextDelegate { model -> onClick(model) }
-            ))
+            )
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/RxDiffAdapter.kt
+++ b/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/RxDiffAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.revolut.recyclerkit.delegates.AbsRecyclerDelegatesAdapter
 import com.revolut.recyclerkit.delegates.DelegatesManager
 import com.revolut.recyclerkit.delegates.ListItem
+import com.revolut.recyclerkit.delegates.RecyclerViewDelegate
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.processors.PublishProcessor
@@ -41,12 +42,24 @@ import java.util.concurrent.TimeUnit
 * @param autoScrollToTop if autoscroll is true then RecyclerView will be scrolled to zero item on update
 * if last zero item was completely visible (i.e. zero scroll).
 */
-open class RxDiffAdapter constructor(
-    delegatesManager: DelegatesManager = DelegatesManager(),
+open class RxDiffAdapter @Deprecated("Replace with constructor without delegates") constructor(
+    delegatesManager: DelegatesManager,
     val async: Boolean = false,
     private val autoScrollToTop: Boolean = false,
     private val detectMoves: Boolean = true
 ) : AbsRecyclerDelegatesAdapter(delegatesManager) {
+
+    constructor(
+        async: Boolean = false,
+        autoScrollToTop: Boolean = false,
+        detectMoves: Boolean = true,
+        delegates: List<RecyclerViewDelegate<out ListItem, out RecyclerView.ViewHolder>>
+    ) : this(
+        async = async,
+        autoScrollToTop = autoScrollToTop,
+        detectMoves = detectMoves,
+        delegatesManager = DelegatesManager(delegates)
+    )
 
     private class Queue<T>(
         val processor: PublishProcessor<T>,
@@ -107,7 +120,7 @@ open class RxDiffAdapter constructor(
     fun onDetachedFromWindow() = queue?.disposable?.dispose()
 
     private fun dispatchDiffInternal(diffResult: DiffUtil.DiffResult, newList: List<ListItem>) {
-        val rv = recyclerView.get() ?: throw IllegalStateException("Recycler View not attached")
+        val rv = recyclerView.get() ?: error("Recycler View not attached")
 
         val firstVisiblePosition = when (val lm = rv.layoutManager) {
             is LinearLayoutManager -> lm.findFirstVisibleItemPosition()


### PR DESCRIPTION
Looks like it's one more extra step for developer, we can get rid of it.

**Before:**
![image](https://user-images.githubusercontent.com/18613737/91273861-83238b00-e786-11ea-9be7-5755c1234a89.png)




**After:**
![image](https://user-images.githubusercontent.com/18613737/91273896-92a2d400-e786-11ea-90f2-5e5aac8191c1.png)
