### PR TITLE
Autoscroll to top if last zero item was completely visible

### DIFF
--- a/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/RxDiffAdapter.kt
+++ b/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/RxDiffAdapter.kt
@@ -123,7 +123,7 @@ open class RxDiffAdapter @Deprecated("Replace with constructor without delegates
         val rv = recyclerView.get() ?: error("Recycler View not attached")
 
         val firstVisiblePosition = when (val lm = rv.layoutManager) {
-            is LinearLayoutManager -> lm.findFirstVisibleItemPosition()
+            is LinearLayoutManager -> lm.findFirstCompletelyVisibleItemPosition()
             else -> 0
         }
 


### PR DESCRIPTION
Adjust firstVisiblePosition detection on RxDiffAdapter to adhere to the description provided:

`if autoscroll is true then RecyclerView will be scrolled to zero item on update if last zero item was completely visible (i.e. zero scroll).`

Current behaviour causes bouncing to the top of the list on update if the first item is partially visible.