### PR TITLE
Added delegates duplicate check

### DIFF
--- a/app/src/main/java/com/revolut/recyclerkit/sample/delegates/PreconditionsCheckNestedItemsDelegate.kt
+++ b/app/src/main/java/com/revolut/recyclerkit/sample/delegates/PreconditionsCheckNestedItemsDelegate.kt
@@ -1,0 +1,26 @@
+package com.revolut.recyclerkit.sample.delegates
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewDelegate
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
+import com.revolut.recyclerkit.delegates.ListItem
+import com.revolut.recyclerkit.delegates.HasNestedDelegates
+import com.revolut.recyclerkit.sample.delegates.PreconditionsCheckNestedItemsDelegate.Model
+import com.revolut.recyclerkit.sample.delegates.PreconditionsCheckNestedItemsDelegate.ViewHolder
+
+class PreconditionsCheckNestedItemsDelegate(
+    override val delegates: List<BaseRecyclerViewDelegate<*, *>>
+) : BaseRecyclerViewDelegate<Model, ViewHolder>(
+    viewType = 0,
+    rule = { _, data -> data is Model }
+), HasNestedDelegates {
+
+    override fun onCreateViewHolder(parent: ViewGroup): ViewHolder =
+        ViewHolder(LayoutInflater.from(parent.context).inflate(viewType, parent, false))
+
+    data class Model(override val listId: String) : ListItem
+
+    class ViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.10.2"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.1"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/delegates/src/main/java/com/revolut/recyclerkit/delegates/HasNestedDelegates.kt
+++ b/delegates/src/main/java/com/revolut/recyclerkit/delegates/HasNestedDelegates.kt
@@ -1,0 +1,25 @@
+package com.revolut.recyclerkit.delegates
+
+/*
+ * Copyright (C) 2019 Revolut
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+interface HasNestedDelegates {
+
+    val delegates: List<RecyclerViewDelegate<*, *>>
+}

--- a/rxdiffadapter/build.gradle
+++ b/rxdiffadapter/build.gradle
@@ -15,6 +15,8 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArgument "runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder"
+
         consumerProguardFiles 'consumer-rules.pro'
     }
 
@@ -29,6 +31,9 @@ android {
         }
     }
 
+    packagingOptions {
+        resources.excludes.add("META-INF/*")
+    }
 }
 
 dependencies {
@@ -36,6 +41,12 @@ dependencies {
     implementation project(':delegates')
     implementation "io.reactivex.rxjava2:rxjava:2.2.19"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
+
+    androidTestImplementation "androidx.test:runner:1.5.2"
+    androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
+    androidTestImplementation "de.mannodermaus.junit5:android-test-core:1.3.0"
+
+    androidTestRuntimeOnly "de.mannodermaus.junit5:android-test-runner:1.3.0"
 }
 
 plugins.withId("com.vanniktech.maven.publish") {

--- a/rxdiffadapter/src/androidTest/java/com/revolut/rxdiffadapter/PreconditionsTest.kt
+++ b/rxdiffadapter/src/androidTest/java/com/revolut/rxdiffadapter/PreconditionsTest.kt
@@ -1,0 +1,107 @@
+package com.revolut.rxdiffadapter
+
+import android.view.View
+import android.view.ViewGroup
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewDelegate
+import com.revolut.recyclerkit.delegates.BaseRecyclerViewHolder
+import com.revolut.recyclerkit.delegates.ListItem
+import com.revolut.recyclerkit.delegates.HasNestedDelegates
+import com.revolut.recyclerkit.delegates.RecyclerViewDelegate
+import com.revolut.rxdiffadapter.PreconditionsTest.TestInnerDelegatesDelegate.Model
+import com.revolut.rxdiffadapter.PreconditionsTest.TestInnerDelegatesDelegate.ViewHolder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class PreconditionsTest {
+
+    @Test
+    fun testErrorWithDuplicatesDetected() = runWithErrorsEnabled {
+        assertThrows<IllegalArgumentException> {
+            RxDiffAdapter(
+                delegates = listOf(
+                    TestDelegateA(),
+                    TestDelegateB(),
+                    TestDelegateB(),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testErrorWithInnerDelegateDuplicatesDetected() = runWithErrorsEnabled {
+        assertThrows<IllegalArgumentException> {
+            RxDiffAdapter(
+                delegates = listOf(
+                    TestDelegateA(),
+                    TestDelegateB(),
+                    TestInnerDelegatesDelegate(
+                        delegates = listOf(
+                            TestDelegateB(),
+                            TestDelegateB(),
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testNoErrorsWithoutDuplicates() = runWithErrorsEnabled {
+        RxDiffAdapter(
+            delegates = listOf(
+                TestDelegateA(),
+                TestDelegateB(),
+                TestInnerDelegatesDelegate(
+                    delegates = listOf(
+                        TestDelegateB(),
+                        TestDelegateA(),
+                    )
+                )
+            )
+        )
+    }
+
+    private fun runWithErrorsEnabled(block: () -> Unit) {
+        RxDiffAdapter.setThrowErrorsOnPreconditions(true)
+        block()
+        RxDiffAdapter.setThrowErrorsOnPreconditions(false)
+    }
+
+    class TestDelegateA : BaseRecyclerViewDelegate<TestDelegateA.Model, TestDelegateA.ViewHolder>(
+        viewType = 0,
+        rule = { _, _ -> true }
+    ) {
+
+        override fun onCreateViewHolder(parent: ViewGroup): ViewHolder = throw RuntimeException("Stub")
+
+        data class Model(override val listId: String) : ListItem
+
+        class ViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView)
+    }
+
+    class TestDelegateB : BaseRecyclerViewDelegate<TestDelegateB.Model, TestDelegateB.ViewHolder>(
+        viewType = 0,
+        rule = { _, _ -> true }
+    ) {
+
+        override fun onCreateViewHolder(parent: ViewGroup): ViewHolder = throw RuntimeException("Stub")
+
+        data class Model(override val listId: String) : ListItem
+
+        class ViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView)
+    }
+
+    class TestInnerDelegatesDelegate(
+        override val delegates: List<RecyclerViewDelegate<*, *>>,
+    ) : BaseRecyclerViewDelegate<Model, ViewHolder>(
+        viewType = 0,
+        rule = { _, _ -> true }
+    ), HasNestedDelegates {
+
+        override fun onCreateViewHolder(parent: ViewGroup): ViewHolder = throw RuntimeException("Stub")
+
+        data class Model(override val listId: String) : ListItem
+
+        class ViewHolder(itemView: View) : BaseRecyclerViewHolder(itemView)
+    }
+}

--- a/rxdiffadapter/src/androidTest/java/com/revolut/rxdiffadapter/PreconditionsTest.kt
+++ b/rxdiffadapter/src/androidTest/java/com/revolut/rxdiffadapter/PreconditionsTest.kt
@@ -80,7 +80,7 @@ class PreconditionsTest {
     }
 
     class TestDelegateB : BaseRecyclerViewDelegate<TestDelegateB.Model, TestDelegateB.ViewHolder>(
-        viewType = 0,
+        viewType = 1,
         rule = { _, _ -> true }
     ) {
 
@@ -94,7 +94,7 @@ class PreconditionsTest {
     class TestInnerDelegatesDelegate(
         override val delegates: List<RecyclerViewDelegate<*, *>>,
     ) : BaseRecyclerViewDelegate<Model, ViewHolder>(
-        viewType = 0,
+        viewType = 2,
         rule = { _, _ -> true }
     ), HasNestedDelegates {
 

--- a/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/Preconditions.kt
+++ b/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/Preconditions.kt
@@ -1,0 +1,38 @@
+package com.revolut.rxdiffadapter
+
+import android.util.Log
+import androidx.recyclerview.widget.RecyclerView
+import com.revolut.recyclerkit.delegates.ListItem
+import com.revolut.recyclerkit.delegates.HasNestedDelegates
+import com.revolut.recyclerkit.delegates.RecyclerViewDelegate
+
+internal object Preconditions {
+
+    private const val TAG: String = "RX_DIFF_ADAPTER"
+
+    var throwErrorsEnabled = false
+
+    fun checkForDuplicateDelegates(delegates: List<RecyclerViewDelegate<out ListItem, out RecyclerView.ViewHolder>>) {
+        delegates.forEach { delegate ->
+            if (delegate is HasNestedDelegates) {
+                checkForDuplicateDelegates(delegate.delegates)
+            } else {
+                val possibleDuplicates = delegates.groupingBy { it::class.java }.eachCount()
+                val hasAnyDuplicates = possibleDuplicates.any { it.value > 1 }
+
+                if (hasAnyDuplicates) {
+                    val message = "Duplicate delegates detected:\n${possibleDuplicates.mapToString()}"
+
+                    if (throwErrorsEnabled) {
+                        throw IllegalArgumentException(message)
+                    } else {
+                        Log.w(TAG, message)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun <K, V> Map<K, V>.mapToString(): String =
+        entries.joinToString(separator = "\n") { (k, v) -> "$k = $v" }
+}

--- a/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/Preconditions.kt
+++ b/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/Preconditions.kt
@@ -17,16 +17,17 @@ internal object Preconditions {
             if (delegate is HasNestedDelegates) {
                 checkForDuplicateDelegates(delegate.delegates)
             } else {
-                val possibleDuplicates = delegates.groupingBy { it::class.java }.eachCount()
+                val possibleDuplicates = delegates.groupingBy { it.viewType }.eachCount()
                 val hasAnyDuplicates = possibleDuplicates.any { it.value > 1 }
 
                 if (hasAnyDuplicates) {
                     val message = "Duplicate delegates detected:\n${possibleDuplicates.mapToString()}"
+                    val error = IllegalArgumentException(message)
 
                     if (throwErrorsEnabled) {
-                        throw IllegalArgumentException(message)
+                        throw error
                     } else {
-                        Log.w(TAG, message)
+                        Log.e(TAG, message, error)
                     }
                 }
             }

--- a/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/RxDiffAdapter.kt
+++ b/rxdiffadapter/src/main/java/com/revolut/rxdiffadapter/RxDiffAdapter.kt
@@ -49,6 +49,13 @@ open class RxDiffAdapter @Deprecated("Replace with constructor without delegates
     private val detectMoves: Boolean = true
 ) : AbsRecyclerDelegatesAdapter(delegatesManager) {
 
+    companion object {
+
+        fun setThrowErrorsOnPreconditions(enabled: Boolean) {
+            Preconditions.throwErrorsEnabled = enabled
+        }
+    }
+
     constructor(
         async: Boolean = false,
         autoScrollToTop: Boolean = false,
@@ -58,7 +65,7 @@ open class RxDiffAdapter @Deprecated("Replace with constructor without delegates
         async = async,
         autoScrollToTop = autoScrollToTop,
         detectMoves = detectMoves,
-        delegatesManager = DelegatesManager(delegates)
+        delegatesManager = DelegatesManager(delegates).also { Preconditions.checkForDuplicateDelegates(delegates) }
     )
 
     private class Queue<T>(
@@ -192,5 +199,4 @@ open class RxDiffAdapter @Deprecated("Replace with constructor without delegates
             }
         }
     }
-
 }


### PR DESCRIPTION
This PR introduces check for duplicate delegates which can be added to the adapter accidentally especially when there's a lot of delegates already there. This will lead to unexpected behaviour when only one delegate produces the events while duplicate is basically lost.

Also there is cases where recycler delegate can contain delegates on their own such as horizontal Recycler view inside vertical one, in order to also check those `HasNestedDelegates` interface is added to check nested delegates as well.

If duplicate is detected by default it will log a warning but this can be changed for dev environment for example just to crash to prevent such issues right away