### PR TITLE
Add class name to error log to make finding the missing delegates easier

### DIFF
--- a/delegates/gradle.properties
+++ b/delegates/gradle.properties
@@ -1,5 +1,5 @@
 POM_ARTIFACT_ID=delegates
-VERSION_NAME=1.1.0
+VERSION_NAME=1.1.1
 POM_NAME=delegates
 POM_PACKAGING=jar
 GROUP=com.revolut.recyclerkit

--- a/delegates/src/main/java/com/revolut/recyclerkit/delegates/DelegatesManager.kt
+++ b/delegates/src/main/java/com/revolut/recyclerkit/delegates/DelegatesManager.kt
@@ -44,7 +44,7 @@ class DelegatesManager(
                 return delegate.viewType
             }
         }
-        error("No delegate found for position $position and object $data ")
+        error("No delegate found for position $position and object ${data.javaClass} - $data")
     }
 
     fun addDelegate(delegate: RecyclerViewDelegate<out ListItem, out RecyclerView.ViewHolder>): DelegatesManager {


### PR DESCRIPTION
Error log for the missing delegate doesn't include class name of the model. 

For example, this is the current error log: 
`java.lang.IllegalStateException: No delegate found for position 0 and object Model(listId=0, text=...)`
If you're not familiar with fields of every delegate, it can be hard to find exact missing delegate. I faced this issue when onboarding 2 new joiners, both struggled with finding the right delegate.

New error log included class name, so if you put model to the Delegate's class, you can easily see the missing delegate:
`java.lang.IllegalStateException: No delegate found for position 0 and object class com.revolut.recyclerkit.sample.delegates.ImageFixedSizeTextDelegate$Model - Model(listId=0, text=...)`