### PR TITLE
onBindViewHolder remove extra allocation of empty payload

### DIFF
--- a/delegates/src/main/java/com/revolut/recyclerkit/delegates/AbsRecyclerDelegatesAdapter.kt
+++ b/delegates/src/main/java/com/revolut/recyclerkit/delegates/AbsRecyclerDelegatesAdapter.kt
@@ -30,13 +30,13 @@ abstract class AbsRecyclerDelegatesAdapter(
         delegatesManager.getDelegateFor(viewType).onCreateViewHolder(parent)
 
     @Suppress("unchecked_cast")
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: MutableList<Any>) {
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: List<Any>) {
         (delegatesManager.getDelegateFor(holder.itemViewType) as RecyclerViewDelegate<ListItem, RecyclerView.ViewHolder>)
             .onBindViewHolder(holder, getItem(position), position, payloads)
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        this.onBindViewHolder(holder, position, mutableListOf())
+        this.onBindViewHolder(holder, position, emptyList())
     }
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {


### PR DESCRIPTION
Using `mutableListOf()` will lead to the allocation of a temporary garbage object on each `onBindViewHolder` without payload, which adds to the overall overhead. 

We can easily avoid this.

And there is no need to keep `MutableList` in

`override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: MutableList<Any>)`

because underlying `RecyclerViewDelegate.onBindViewHolder` has `List` in signature